### PR TITLE
fix(deps): allow studio v4 in peer dep ranges

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,11 +105,20 @@ jobs:
     runs-on: ubuntu-latest
     name: Semantic release
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           # Need to fetch entire commit history to
           # analyze every commit since last release
           fetch-depth: 0
+          # Uses generated token to allow pushing commits back
+          token: ${{ steps.app-token.outputs.token }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           cache: npm
@@ -117,17 +126,7 @@ jobs:
       - run: npm ci
         # Branches that will release new versions are defined in .releaserc.json
       - run: npx semantic-release
-        # Don't allow interrupting the release step if the job is cancelled, as it can lead to an inconsistent state
-        # e.g. git tags were pushed but it exited before `npm publish`
-        if: always()
         env:
           NPM_CONFIG_PROVENANCE: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-        # Re-run semantic release with rich logs if it failed to publish for easier debugging
-      - run: npx semantic-release --dry-run --debug
-        if: failure()
-        env:
-          NPM_CONFIG_PROVENANCE: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
       },
       "peerDependencies": {
         "react": "^18.2.0 || ^19",
-        "sanity": "^3.36.4",
+        "sanity": "^3.36.4 || ^4.0.0-0",
         "styled-components": "^6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "react": "^18.2.0 || ^19",
-    "sanity": "^3.36.4",
+    "sanity": "^3.36.4 || ^4.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {


### PR DESCRIPTION
### Description

Prepping for July 15th: https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason#299526b398ec

Currently when using a package.json like: 
```
Progress: resolved 1029, reused 0, downloaded 0, added 0, done
 WARN  Issues with peer dependencies found
.
└─┬ @sanity/studio-secrets 3.0.1
  └── ✕ unmet peer sanity@^3.36.4: found 4.0.0-0
Done in 6s using pnpm v10.12.1


```
This fixes it.

### Testing

Tested locally
