### PR TITLE
fix(deps): make peer dependencies include sanity 5.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
       },
       "peerDependencies": {
         "react": "^18.2.0 || ^19",
-        "sanity": "^3.36.4 || ^4.0.0-0",
+        "sanity": "^3.36.4 || ^4.0.0-0 || ^5.0.0",
         "styled-components": "^6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "react": "^18.2.0 || ^19",
-    "sanity": "^3.36.4 || ^4.0.0-0",
+    "sanity": "^3.36.4 || ^4.0.0-0 || ^5.0.0",
     "styled-components": "^6.1"
   },
   "engines": {


### PR DESCRIPTION
### Description
This pull request updates the peer dependencies to support Sanity version 5.x, allowing the plugin to work with the latest major version of Sanity Studio while maintaining backward compatibility with versions 3.x and 4.x.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
